### PR TITLE
fix: implement route-scoped scroll keys to fix scroll resets

### DIFF
--- a/src/ComponentsSelf/mylistnavbar.tsx
+++ b/src/ComponentsSelf/mylistnavbar.tsx
@@ -124,6 +124,7 @@ export default function MyListNavbar({
     sessionStorage.removeItem('sorted_anime');
     sessionStorage.removeItem('slicearr');
     sessionStorage.removeItem('scrollY');
+    sessionStorage.removeItem('scrollY_/mylist');
   }
 
   function Filereader(e: React.ChangeEvent<HTMLInputElement>) {

--- a/src/app/_components/HomeClient.tsx
+++ b/src/app/_components/HomeClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useScrollSaver } from "@/hooks/use-scroll-saver";
 import Nav from "@/ComponentsSelf/navbar";
 import LastSeason from "@/ComponentsSelf/LastSeason";
 import { CarouselDemo } from "@/ComponentsSelf/carousel";
@@ -37,6 +38,8 @@ export default function HomeClient({
 }: HomeClientProps) {
   const router = useRouter();
 
+  useScrollSaver();
+
   // Auth Session token refresh
   useEffect(() => {
     const checkSession = async () => {
@@ -69,7 +72,6 @@ export default function HomeClient({
       sessionStorage.removeItem("animedatasearch");
       sessionStorage.removeItem("lastupdatetimesearch");
       sessionStorage.setItem("activetab", "Plan To Watch");
-      sessionStorage.setItem("scrollY", "0");
       sessionStorage.setItem("slicearr", JSON.stringify(30));
     } catch (e) {
       console.error("Failed to write to sessionStorage:", e);

--- a/src/hooks/use-scroll-reset.test.ts
+++ b/src/hooks/use-scroll-reset.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isListPage, isPathInFlow } from "./use-scroll-reset";
+
+describe("useScrollReset helpers", () => {
+  describe("isListPage", () => {
+    it("identifies list pages correctly", () => {
+      expect(isListPage("/")).toBe(true);
+      expect(isListPage("/mylist")).toBe(true);
+      expect(isListPage("/seasons")).toBe(true);
+      expect(isListPage("/seasons/summer/2024")).toBe(true);
+      expect(isListPage("/search")).toBe(true);
+      expect(isListPage("/search/naruto")).toBe(true);
+      expect(isListPage("/morethiseseason")).toBe(true);
+      expect(isListPage("/morelastseason")).toBe(true);
+      expect(isListPage("/moreupcoming")).toBe(true);
+    });
+
+    it("identifies non-list pages correctly", () => {
+      expect(isListPage("/Anime/12345")).toBe(false);
+      expect(isListPage("/seasons/summer/2024/12345")).toBe(false);
+      expect(isListPage("/mylist/Watching/12345")).toBe(false);
+      expect(isListPage("/mylist/user_profile")).toBe(false);
+      expect(isListPage("/morethiseseason/12345")).toBe(false);
+    });
+  });
+
+  describe("isPathInFlow", () => {
+    it("matches pages in the same list flow", () => {
+      // MyList flow
+      expect(isPathInFlow("/mylist", "/mylist/Watching/123")).toBe(true);
+      expect(isPathInFlow("/mylist", "/mylist/Watching/123/relation/456")).toBe(true);
+      expect(isPathInFlow("/mylist", "/mylist/Watching/123/tracking")).toBe(true);
+      expect(isPathInFlow("/mylist", "/mylist/Watching/123/relation/456/tracking")).toBe(true);
+
+      // Seasons flow
+      expect(isPathInFlow("/seasons/summer/2024", "/seasons/summer/2024/123")).toBe(true);
+      expect(isPathInFlow("/seasons/summer/2024", "/seasons/summer/2024/123/relation/456")).toBe(true);
+
+      // Home flow
+      expect(isPathInFlow("/", "/Anime/123")).toBe(true);
+      expect(isPathInFlow("/", "/Anime/123/relation/456")).toBe(true);
+
+      // Search flow
+      expect(isPathInFlow("/search/naruto", "/search/naruto/123")).toBe(true);
+      expect(isPathInFlow("/search/naruto", "/search/naruto/123/relation/456")).toBe(true);
+    });
+
+    it("does not match pages in different flows", () => {
+      expect(isPathInFlow("/mylist", "/morethiseseason/123")).toBe(false);
+      expect(isPathInFlow("/seasons/summer/2024", "/mylist/Watching/123")).toBe(false);
+      expect(isPathInFlow("/", "/mylist")).toBe(false);
+    });
+  });
+});

--- a/src/hooks/use-scroll-reset.ts
+++ b/src/hooks/use-scroll-reset.ts
@@ -1,0 +1,52 @@
+"use client";
+
+export function isListPage(pathname: string): boolean {
+  const path = pathname.replace(/\/$/, "");
+  
+  if (path === "" || path === "/") {
+    return true;
+  }
+
+  const segments = path.split("/");
+
+  if (segments[1] === "seasons") {
+    return segments.length === 2 || segments.length === 4;
+  }
+
+  if (segments[1] === "search") {
+    return segments.length === 2 || segments.length === 3;
+  }
+
+  const simpleLists = [
+    "/mylist",
+    "/morethiseseason",
+    "/morelastseason",
+    "/moreupcoming",
+  ];
+  return simpleLists.includes(path);
+}
+
+export function isPathInFlow(currentList: string, newPathname: string): boolean {
+  if (!currentList) return false;
+
+  const listPath = currentList.replace(/\/$/, "");
+  const newPath = newPathname.replace(/\/$/, "");
+
+  if (newPath === listPath) return true;
+
+  if (listPath === "" || listPath === "/") {
+    return /^\/Anime\/\d+(?:\/relation\/\d+)?(?:\/tracking)?$/i.test(newPath);
+  }
+
+  if (listPath.startsWith("/mylist")) {
+    return /^\/mylist\/[^/]+\/\d+(?:\/relation\/\d+)?(?:\/tracking)?$/i.test(newPath);
+  }
+
+  const escaped = listPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped}/\\d+(?:/relation/\\d+)?(?:/tracking)?$`, "i");
+  return regex.test(newPath);
+}
+
+export function useScrollReset() {
+  // Obsolete: route-scoped scroll keys inside useScrollSaver handle this natively now.
+}

--- a/src/hooks/use-scroll-saver.test.ts
+++ b/src/hooks/use-scroll-saver.test.ts
@@ -4,6 +4,7 @@ import {
   restoreScrollPosition,
   saveScrollPosition,
   SCROLL_STORAGE_KEY,
+  getScrollStorageKey,
 } from "./use-scroll-saver";
 
 describe("scroll saver helpers", () => {
@@ -27,27 +28,27 @@ describe("scroll saver helpers", () => {
   it("saves and reads valid scroll positions", () => {
     saveScrollPosition(window.sessionStorage, 120);
 
-    expect(window.sessionStorage.getItem(SCROLL_STORAGE_KEY)).toBe("120");
+    expect(window.sessionStorage.getItem(getScrollStorageKey())).toBe("120");
     expect(readScrollPosition(window.sessionStorage)).toBe(120);
   });
 
   it("rejects invalid stored scroll positions", () => {
-    window.sessionStorage.setItem(SCROLL_STORAGE_KEY, "-1");
+    window.sessionStorage.setItem(getScrollStorageKey(), "-1");
     expect(readScrollPosition(window.sessionStorage)).toBeNull();
 
-    window.sessionStorage.setItem(SCROLL_STORAGE_KEY, "not-a-number");
+    window.sessionStorage.setItem(getScrollStorageKey(), "not-a-number");
     expect(readScrollPosition(window.sessionStorage)).toBeNull();
   });
 
   it("restores only valid positions within the document bounds", () => {
     const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 
-    window.sessionStorage.setItem(SCROLL_STORAGE_KEY, "20");
+    window.sessionStorage.setItem(getScrollStorageKey(), "20");
     expect(restoreScrollPosition({ storage: window.sessionStorage, maxOffset: 1000 })).toBe(true);
     expect(scrollTo).toHaveBeenCalledWith(0, 20);
 
     scrollTo.mockClear();
-    window.sessionStorage.setItem(SCROLL_STORAGE_KEY, "999999");
+    window.sessionStorage.setItem(getScrollStorageKey(), "999999");
     expect(restoreScrollPosition({ storage: window.sessionStorage, maxOffset: 0 })).toBe(false);
     expect(scrollTo).not.toHaveBeenCalled();
   });

--- a/src/hooks/use-scroll-saver.ts
+++ b/src/hooks/use-scroll-saver.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import type { DependencyList } from "react";
+import { usePathname } from "next/navigation";
 
 export const SCROLL_STORAGE_KEY = "scrollY";
 
@@ -14,22 +15,30 @@ function getSessionStorage(): Storage | undefined {
   }
 }
 
-export function saveScrollPosition(storage?: Storage, y?: number): void {
+export function getScrollStorageKey(pathname?: string): string {
+  if (typeof window === "undefined") return SCROLL_STORAGE_KEY;
+  const path = pathname ?? window.location.pathname;
+  return `${SCROLL_STORAGE_KEY}_${path}`;
+}
+
+export function saveScrollPosition(storage?: Storage, y?: number, pathname?: string): void {
   const targetStorage = storage ?? getSessionStorage();
   if (typeof window === "undefined" || !targetStorage) return;
   try {
     const scrollY = y !== undefined ? y : window.scrollY;
-    targetStorage.setItem(SCROLL_STORAGE_KEY, String(scrollY));
+    const key = getScrollStorageKey(pathname);
+    targetStorage.setItem(key, String(scrollY));
   } catch (e) {
     console.error("Failed to save scroll position", e);
   }
 }
 
-export function readScrollPosition(storage?: Storage): number | null {
+export function readScrollPosition(storage?: Storage, pathname?: string): number | null {
   const targetStorage = storage ?? getSessionStorage();
   if (typeof window === "undefined" || !targetStorage) return null;
   try {
-    const val = targetStorage.getItem(SCROLL_STORAGE_KEY);
+    const key = getScrollStorageKey(pathname);
+    const val = targetStorage.getItem(key);
     if (val === null) return null;
     const num = Number(val);
     if (Number.isFinite(num) && num >= 0) {
@@ -41,13 +50,13 @@ export function readScrollPosition(storage?: Storage): number | null {
   return null;
 }
 
-export function restoreScrollPosition(options?: { maxOffset?: number; storage?: Storage }): boolean {
+export function restoreScrollPosition(options?: { maxOffset?: number; storage?: Storage; pathname?: string }): boolean {
   if (typeof window === "undefined") return false;
   const storage = options?.storage ?? getSessionStorage();
   if (!storage) return false;
   const maxOffset = options?.maxOffset ?? 100;
 
-  const savedY = readScrollPosition(storage);
+  const savedY = readScrollPosition(storage, options?.pathname);
   if (savedY === null) return false;
 
   const maxScroll = document.documentElement.scrollHeight - window.innerHeight + maxOffset;
@@ -60,13 +69,14 @@ export function restoreScrollPosition(options?: { maxOffset?: number; storage?: 
 
 export function useScrollSaver(deps: DependencyList = []): void {
   const isRestored = useRef(false);
+  const pathname = usePathname();
   void deps;
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const handleSave = () => {
-      saveScrollPosition();
+      saveScrollPosition(undefined, undefined, pathname);
     };
 
     const handleUserInteraction = () => {
@@ -84,7 +94,7 @@ export function useScrollSaver(deps: DependencyList = []): void {
         if (target.tagName === "A") {
           const href = target.getAttribute("href");
           if (href && (href.startsWith("/") || href.startsWith(window.location.origin))) {
-            saveScrollPosition();
+            saveScrollPosition(undefined, undefined, pathname);
           }
           break;
         }
@@ -101,11 +111,11 @@ export function useScrollSaver(deps: DependencyList = []): void {
       window.removeEventListener("touchmove", handleUserInteraction);
       document.removeEventListener("click", handleLinkClick, { capture: true });
     };
-  }, []);
+  }, [pathname]);
 
   useEffect(() => {
     if (!isRestored.current) {
-      const restored = restoreScrollPosition();
+      const restored = restoreScrollPosition({ pathname });
       if (restored) {
         isRestored.current = true;
       }


### PR DESCRIPTION
This PR fixes scroll reset wankiness on back navigations and carousel navigations by introducing route-scoped scroll keys inside useScrollSaver.